### PR TITLE
Hardcode getTimes to support DATE type EXDATE

### DIFF
--- a/packages/icalendar/src/ical-expander/IcalExpander.js
+++ b/packages/icalendar/src/ical-expander/IcalExpander.js
@@ -86,7 +86,7 @@ export class IcalExpander {
           if (next) {
             const occurrence = event.getOccurrenceDetails(next);
 
-            const { startTime, endTime } = getTimes(occurrence);
+            const { startTime, endTime } = getTimes(occurrence, true);
 
             const isOccurrenceExcluded = exdates.indexOf(startTime) !== -1;
 


### PR DESCRIPTION
Since our project only has DATE type EXDATE values, hardcode all EXDATE checking to use only dates.